### PR TITLE
Initial commit for EOA improvement RIP-7560 transaction subtypes

### DIFF
--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -42,7 +42,7 @@ Here is the list of EIPs that propose adding features to EOA accounts that are a
 Each one of these proposals introduces features that can benefit both existing users and potential future users of
 the Ethereum blockchain in multiple ways.
 
-However, together these proposals consist of 3 different transaction types and 3 opcodes, which is probably unsustainable.
+However, together these proposals consist of 3 different transaction types and 3 opcodes, which is probably unsustainable. The transaction types are incompatible with each other, forcing the user to only use one.
 
 None of these proposals supports Gas Abstraction mechanism that would be conceptually similar to "Paymasters" - smart
 contracts capable of paying transaction gas, based on some on-chain validity function, but do not gain any

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -62,6 +62,7 @@ These proposals cannibalize each other's use-cases, but do not fully resolve the
 currently suffering from, and they do not fully align with any kind of vision for a Full Native Account Abstraction.
 
 ## Specification
+The aforementioned EIPs can be implemented by the following transaction subtypes:
 
 ### Shared RIP-9999 transaction payload
 

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -267,6 +267,15 @@ Here are some of the benefits of a transaction subtype approach:
 users to fully hand over control of their accounts to the gas paying "invoker" contract.
 A lot can go wrong with this approach.
 
+    Another benefit is that it allows smart accounts and EOAs to use the same paymasters.
+
+    A dapp that sponsors a transaction doesn't have to care whether the user has a smart account or an EOA.
+    And paymasters like TokenPaymaster could allow both smart accounts and EOAs to pay with
+    [ERC-20](./eip-20) tokens.
+
+    The 3074-based approach, in contrast, would require developing separate gas abstraction invokers and dapps
+    would have to be aware of the user's account type.
+
 * Use of `AUTH` and `AUTHCALL` opcodes for Gas Abstraction introduces risks to the block building task.
 
     If the block builder relies on a Gas Abstraction mechanism to pay for transaction gas, it will require a protection

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -177,7 +177,7 @@ The transaction payload for this subtype is extended with the following fields:
 ```
  chainId,
  nonce,
- invokerAddress,
+ implementationAddress,
  callData,
  callGasLimit
  bigNonce, // TBD: in this transaction we would need both nonces - account state and 2D

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -123,8 +123,8 @@ enabling Gas Abstracted new smart contract deployment.
 BATCHED_EOA_SUBTYPE = x
 ```
 
-This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to initialize multiple
-EOA calls with a single signature and a single Paymaster validation.
+This transaction subtype extends the functionality of RIP-7560 EOA transactions with an ability to initialize
+multiple EOA calls with a single signature and a single Paymaster validation.
 
 
 The transaction payload for this subtype is extended with the following fields:
@@ -163,7 +163,7 @@ The transaction payload for this subtype is extended with the following fields:
  yParity, r, s
 ```
 
-This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to execute arbitrary
+This transaction subtype extends the functionality of RIP-7560 EOA transactions with an ability to execute arbitrary
 contract code in the context of the EOA sender.
 
 Note that such transaction provides a one-time signature delegating execution to the `destination` contract,
@@ -185,7 +185,7 @@ The transaction payload for this subtype is extended with the following fields:
  yParity, r, s
 ```
 
-This transaction subtype extends the `DELEGATED_EOA_SUBTYPE` transactions with an ability to authorize some
+This transaction subtype extends the functionality of RIP-7560 EOA transactions with an ability to authorize some
 contract code to act as a Smart Contract Account and control the context of the EOA sender.
 
 The transaction signature (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the `secp256k1` curve over
@@ -233,7 +233,7 @@ without ever needing to deploy code for the contract.
 INSERT_CODE_EOA_SUBTYPE
 ```
 
-This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to insert
+This transaction subtype extends the functionality of RIP-7560 EOA transactions with an ability to insert
 contract code in the context of the EOA sender.
 
 The transaction payload for this subtype is extended with the following fields:

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -76,9 +76,11 @@ These are the shared parameters of any RIP-9999 transaction subtype payload:
 ```
   chainId,
   nonce,
-  callData,
+  paymaster,
   paymasterData,
-  paymasterGasLimit,
+  callData,
+  paymasterValidationGasLimit,
+  paymasterPostOpGasLimit,
   maxPriorityFeePerGas,
   maxFeePerGas,
   validAfter,
@@ -231,27 +233,26 @@ without ever needing to deploy code for the contract.
 INSERT_CODE_EOA_SUBTYPE
 ```
 
-[//]: # (TODO: 7377 probably needs codeAddr/storage simply because it has no deployment frame; we can have initCode)
-
 This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to insert
 contract code in the context of the EOA sender.
 
 The transaction payload for this subtype is extended with the following fields:
 ```
 callGasLimit,
-codeAddr,
-storage,
-data,
-value
+initCode,
+value,
+yParity, r, s
 ```
 
-[//]: # (TODO: TBD: this is copied directly from 7377 as it seems to apply well.)
+The `initCode` is executed in the context of the account address that is recovered from the
+signature parameters (`yParity`, `r`, `s`).
 
-Unlike standard contract deployment, a migration transaction directly specifies what code value the sender's
-account should be set to.
+Same as the regular transaction, the data returned by executing the `initCode` is stored as the contract code
+for the signer's account address.
 
-As the first step of processing the transaction, set the sender’s code to `state[tx.codeAddr].code`.
-Next, for each tuple in `storage` and the sender’s storage trie, set `storage[t.first] = t.second`.
+In case the returned value is not a valid contract code the transaction reverts all changes except for gas charge.
+
+In case the signer's account address contains code before `initCode` runs the transaction reverts immediately.
 
 ## Rationale
 

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -133,10 +133,10 @@ The transaction payload for this subtype is extended with the following fields:
  atomicity,
  yParity, r, s
 ```
-The `targets` parameter is interpreted as an RPL encoding of `N` destination addressed.
-The `values` parameter is interpreted as an RPL encoding of `N` 256-bit amounts.
-The `callData` parameter is interpreted as an RPL encoding of `N` call data byte arrays.
-The `gasLimits` parameter is interpreted as an RPL encoding of `N` 256-bit gas limit values.
+The `targets` parameter is interpreted as an RLP encoding of `N` destination addressed.
+The `values` parameter is interpreted as an RLP encoding of `N` 256-bit amounts.
+The `callData` parameter is interpreted as an RLP encoding of `N` call data byte arrays.
+The `gasLimits` parameter is interpreted as an RLP encoding of `N` 256-bit gas limit values.
 
 The field `atomicity` contains an RLP encoded array of `N` elements of `byte` "atomicity" values.
 Atomicity describes a behaviour in case of a top-level revert in one of the frames, and can take the following values:

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -13,17 +13,18 @@ requires: 7560
 
 ## Abstract
 
-Using the Gas Abstraction feature of [RIP-7560](./rip-7560.md) transaction multiple execution frames approach,
-but applying the same approach to transactions authorized by being signed by an Externally Owned Account private keys,
+Using the Gas Abstraction feature of [RIP-7560](./rip-7560.md) transactions with multiple execution frames,
+but applying the same approach to transactions authorized with a signature created by an Externally Owned Account,
 we define extensions to existing EOA behaviour that are consistent with the current state of Account Abstraction debate.
 
 ## Motivation
 
 The design work around Account Abstraction in Ethereum has started with
 [EIP-86: Abstraction of transaction origin and signature](https://eips.ethereum.org/EIPS/eip-86)
-back in 2017, however it there has recently been a lot of interest in implementing some sort of extension
-to existing EOA functionality that can either be seen as a step towards "Full Native Account Abstraction",
-or be evaluated on their own merit regardless of the eventual Account Abstraction design.
+back in 2017, however there has recently been an increased interest in implementing some sort of extension
+to existing EOA functionality.
+These "EOA extensions" can either be seen as a step towards "Full Native Account
+Abstraction", or be evaluated on their own merit regardless of the eventual Account Abstraction design.
 
 This proposal is intended to prevent the fragmentation and inconsistencies that may arise as a result of implementing
 multiple independent standalone proposals by combining all of them into a unified design.
@@ -42,29 +43,33 @@ the Ethereum blockchain in multiple ways.
 
 However, together these proposals consist 3 different transaction types and 3 opcodes, which is probably unsustainable.
 
-None of these proposals supports Gas Abstraction that would be conceptually similar to "Paymasters" - smart contracts
-capable of paying transaction gas, based on some on-chain validity function, but do not gain any
-privileged access to sender's funds - despite this concept being widely used in production by
+None of these proposals supports Gas Abstraction mechanism that would be conceptually similar to "Paymasters" - smart
+contracts capable of paying transaction gas, based on some on-chain validity function, but do not gain any
+privileged access to sender's funds.
+This is very disappointing given that the concept of "Paymasters" has being widely used in production by
 [ERC-4337: Account Abstraction Using Alt Mempool](https://eips.ethereum.org/EIPS/eip-4337)
 and even
 [ERC-1613: Gas Stations Network](https://eips.ethereum.org/EIPS/eip-1613)
 before that.
 
 None of these proposals fully support validity time ranges, which enable both scheduled and expiring transactions,
-which adds a noticeable improvement to end-user experience with a relatively small amount of effort.
+adding a noticeable improvement to end-user experience with a relatively small amount of effort.
 
-And most importantly none of these proposals forms a part of a bigger vision, instead being an isolated patch
-that can be applied in a single design iteration. These proposals cannibalize each other's use-cases, but do not
-fully resolve the pain points Ethereum users are currently suffering from, and do not fully align with the vision
-of Full Native Account Abstraction.
+And most importantly, none of these proposals form a part of a bigger vision.
+Instead, these proposals are isolated patches that can be applied in a single design iteration.
+These proposals cannibalize each other's use-cases, but do not fully resolve the pain points Ethereum users are
+currently suffering from, and they do not fully align with any kind of vision for a Full Native Account Abstraction.
 
 ## Specification
 
 ### Shared RIP-9999 transaction payload
 
 The required synergy of the proposed transaction subtypes is achieved by defining a shared base structure of
-a transaction. This will ensure the only differences between these subtypes are the strictly required
-by their semantics instead of being implementation details.
+a transaction.
+This will ensure the only differences between these subtypes are the ones strictly required
+by their semantics instead of being caused by different tastes or variations in implementation details.
+
+These are the shared parameters of any RIP-9999 transaction subtype payload:
 
 ```
   chainId,
@@ -81,6 +86,8 @@ by their semantics instead of being implementation details.
 ```
 
 ### Gas-sponsored time-limited EOA transaction subtype
+
+[//]: # (TODO: remove this type, it is just a speacial case of batched tx with N=1)
 
 ```
 SPONSORED_EOA_SUBTYPE = x
@@ -235,6 +242,8 @@ a randomized signature value, without ever knowing the ECDSA private key that wo
 Applying this approach to an `AUTHORIZED_EOA_SUBTYPE` transaction, a new account can be created,
 whose address is forever bound to `invokerAddress` and `commit`, without ever needing to deploy code for the contract.
 
+[//]: # (TODO: 3074 allows a single transaction to carry multiple authorizations, and switch between them dynamically)
+[//]: # (TODO: should we try to do something similar with batched delegation/authorization?)
 
 ### Gas-sponsored time-limited code injection EOA transaction subtype
 
@@ -242,11 +251,48 @@ whose address is forever bound to `invokerAddress` and `commit`, without ever ne
 INSERT_CODE_EOA_SUBTYPE
 ```
 
+[//]: # (TODO: 7377 probably needs codeAddr/storage simply because it has no deployment frame; we can have initCode)
+
 This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to insert
 contract code in the context of the EOA sender.
 
+The transaction payload for this subtype is extended with the following fields:
+```
+callGasLimit,
+codeAddr,
+storage,
+data,
+value
+```
 
 ## Rationale
+
+### Authorization as a transaction subtype instead of a family of opcodes
+
+Both approaches have their benefits and downsides.
+Here are ome of the benefits of a transaction subtype approach:
+
+* Use of `AUTH` and `AUTHCALL` opcodes only allow an unnecessarily dangerous way for EOAs to achieve Gas Abstraction.
+
+    While technically it is possible to implement a gas relaying feature on top of EIP-3074, this approach requires
+users to fully hand over control of their accounts to the gas paying "invoker" contract.
+A lot can go wrong with this approach.
+
+* Use of `AUTH` and `AUTHCALL` opcodes for Gas Abstraction introduces risks to the block building task.
+
+    If the block builder relies on a Gas Abstraction mechanism to pay for transaction gas, it will require a protection
+mechanism similar to [ERC-7562: Account Abstraction Validation Scope Rules](https://eips.ethereum.org/EIPS/eip-7562).
+
+    It is impossible to retrofit such mechanism into legacy transaction types.
+
+* Avoids exposing ECDSA signature and account nonces to the EVM opcodes.
+    Using opcodes to verify authorization signature necessarily means that EVM becomes exposed to these details.
+
+* There is only a limited number of available opcodes across all L1 and L2 networks.
+
+    Transaction types are also limited, however with subtypes the namespace is basically unlimited.
+
+    This makes it easier to avoid network splits, as well as to introduce changes to authorisation behaviour if necessary.
 
 ## Backwards Compatibility
 

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -13,9 +13,72 @@ requires: 7560
 
 ## Abstract
 
+Using the Gas Abstraction feature of [RIP-7560](./rip-7560.md) transaction multiple execution frames approach,
+but applying the same approach to transactions authorized by being signed by an Externally Owned Account private keys,
+we define extensions to existing EOA behaviour that are consistent with the current state of Account Abstraction debate.
+
 ## Motivation
 
+The design work around Account Abstraction in Ethereum has started with
+[EIP-86: Abstraction of transaction origin and signature](https://eips.ethereum.org/EIPS/eip-86)
+back in 2017, however it there has recently been a lot of interest in implementing some sort of extension
+to existing EOA functionality that can either be seen as a step towards "Full Native Account Abstraction",
+or be evaluated on their own merit regardless of the eventual Account Abstraction design.
+
+This proposal is intended to prevent the fragmentation and inconsistencies that may arise as a result of implementing
+multiple independent standalone proposals by combining all of them into a unified design.
+
+Here is the list of EIPs that propose adding features to EOA accounts that are addressed by this document:
+
+* [EIP-2711: Sponsored, expiring and batch transactions](https://eips.ethereum.org/EIPS/eip-2711)
+* [EIP-3074: AUTH and AUTHCALL opcodes](https://eips.ethereum.org/EIPS/eip-3074)
+* [EIP-5003: Insert Code into EOAs with AUTHUSURP](https://eips.ethereum.org/EIPS/eip-5003)
+* [EIP-5081: Expirable Transaction](https://eips.ethereum.org/EIPS/eip-5081)
+* [EIP-5806: Delegate transaction](https://eips.ethereum.org/EIPS/eip-5806)
+* [EIP-7377: Migration Transaction](https://eips.ethereum.org/EIPS/eip-7377)
+
+Each one of these proposals introduces features that can benefit both existing users and potential future users of
+the Ethereum blockchain in multiple ways.
+
+However, together these proposals consist 3 different transaction types and 3 opcodes, which is probably unsustainable.
+
+None of these proposals supports Gas Abstraction that would be conceptually similar to "Paymasters" - smart contracts
+capable of paying transaction gas, based on some on-chain validity function, but do not gain any
+privileged access to sender's funds - despite this concept being widely used in production by
+[ERC-4337: Account Abstraction Using Alt Mempool](https://eips.ethereum.org/EIPS/eip-4337)
+and even
+[ERC-1613: Gas Stations Network](https://eips.ethereum.org/EIPS/eip-1613)
+before that.
+
+None of these proposals fully support validity time ranges, which enable both scheduled and expiring transactions,
+which adds a noticeable improvement to end-user experience with a relatively small amount of effort.
+
+And most importantly none of these proposals forms a part of a bigger vision, instead being an isolated patch
+that can be applied in a single design iteration. These proposals cannibalize each other's use-cases, but do not
+fully resolve the pain points Ethereum users are currently suffering from, and do not fully align with the vision
+of Full Native Account Abstraction.
+
 ## Specification
+
+### Shared RIP-9999 transaction payload
+
+The required synergy of the proposed transaction subtypes is achieved by defining a shared base structure of
+a transaction. This will ensure the only differences between these subtypes are the strictly required
+by their semantics instead of being implementation details.
+
+```
+  chainId,
+  nonce,
+  callData,
+  paymasterData,
+  paymasterGasLimit,
+  maxPriorityFeePerGas,
+  maxFeePerGas,
+  validAfter,
+  validUntil,
+  accessList,
+  yParity, r, s
+```
 
 ### Gas-sponsored time-limited EOA transaction subtype
 
@@ -23,18 +86,29 @@ requires: 7560
 SPONSORED_EOA_SUBTYPE = x
 ```
 
-This transaction subtype allows replacing a Smart Contract Account validation with a more familiar ECDSA validation
-pattern used in existing transaction types 0, 1 and 2.
+This RIP-7560 transaction subtype allows ECDSA signature and nonce validation, same as the one used in all
+of existing transaction types, to be applied to a transaction that can also provide `paymasterData`, `validAfter`
+and `validUntil` parameters.
 
-However, it retains the ability of an RIP-7560 transaction to include Paymaster data in order for the Paymaster
-contract to accept the gas charges. It also retains an ability to explicitly specify a time range where this
+The transaction payload for this subtype is extended with the following fields:
+```
+ to
+ value
+ callGasLimit
+```
+
+This change extends the ability of an RIP-7560 transaction to include Paymaster data in order for the Paymaster
+contract to accept the gas charges to all existing EOA accounts.
+It also provided an EOA with an ability to explicitly specify a time range where this
 transaction is valid, creating both "expiring" and "delayed" transactions.
 
-In case the `to` field is `nil`, `callData` is treated as `initCode` for the purpose of contract creation.
+In case the `to` field is `nil`, `callData` is treated as `initCode` for the purpose of contract creation,
+enabling Gas Abstracted new smart contract deployment.
 
-https://eips.ethereum.org/EIPS/eip-2711
+
 
 ### Gas-sponsored time-limited batched execution EOA transaction subtype
+
 
 ```
 BATCHED_EOA_SUBTYPE = x
@@ -43,21 +117,39 @@ BATCHED_EOA_SUBTYPE = x
 This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to initialize multiple
 EOA calls with a single signature and a single Paymaster validation.
 
-Fields `to` and `callData` are replaced with fields `targets` and `callDatas` containing RLP encoded arrays of values.
 
-The field `atomicity` contains an RLP encoded array of `byte` "atomicity" values.
+The transaction payload for this subtype is extended with the following fields:
+```
+ targets
+ values
+ gasLimits
+ atomicity
+```
+The `targets` parameter is interpreted as an RPL encoding of `N` destination addressed.
+The `values` parameter is interpreted as an RPL encoding of `N` 256-bit amounts.
+The `callData` parameter is interpreted as an RPL encoding of `N` call data byte arrays.
+The `gasLimits` parameter is interpreted as an RPL encoding of `N` 256-bit gas limit values.
+
+The field `atomicity` contains an RLP encoded array of `N` elements of `byte` "atomicity" values.
 Atomicity describes a behaviour in case of a top-level revert in one of the frames, and can take the following values:
 
 * `CONTINUE_ON_REVERT = 0` - ignores the reverted execution and continues executing the batch
 * `TERMINATE_ON_REVERT = 1` - stops the execution of the batch on the reverted execution, does not execute the remainder
 * `ROLLBACK_ON_REVERT = 2` - rolls back all state changes caused by all the execution frames in current transaction
 
-https://eips.ethereum.org/EIPS/eip-2711
+These parameters represent all the inputs necessary to perform `N` sub-transactions.
+
 
 ### Gas-sponsored time-limited one-time delegated EOA transaction subtype
 
 ```
 DELEGATED_EOA_SUBTYPE = x
+```
+
+The transaction payload for this subtype is extended with the following fields:
+```
+ destination
+ callGasLimit
 ```
 
 This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to execute arbitrary
@@ -67,12 +159,21 @@ Note that such transaction provides a one-time signature delegating execution to
 and this signature cannot be used repeatedly. The private key of the EOA will be needed to sign consequent delegations.
 
 TODO: Opcode restrictions (SSTORE, CREATE, CREATE2)
-See https://eips.ethereum.org/EIPS/eip-5806
 
 ### Gas-sponsored time-limited reusable authorization EOA transaction subtype
 
 ```
 AUTHORIZED_EOA_SUBTYPE = x
+```
+
+The transaction payload for this subtype is extended with the following fields:
+```
+ chainId,
+ nonce,
+ invokerAddress,
+ commit,
+ callData,
+ callGasLimit
 ```
 
 This transaction subtype extends the `DELEGATED_EOA_SUBTYPE` transactions with an ability to authorize arbitrary
@@ -92,10 +193,30 @@ for a transaction validity:
 AUTHORIZED_EOA_SUBTYPE is not valid if a transaction with identical hash has alredy been included in the current chain
 ```
 
-Note that Paymaster Data is not signed, so different Paymaster contracts can be used for subsequent
-authorized transactions.
+Note that most of the transaction fields are not signed by this transaction's signature. This means that the "invoker"
+contract is the entity responsible for implementing all kinds of protections, and the EOA account that signs an
+authorization fully cedes control to the "invoker" until the authorization is revoked.
+
+For the purposes of Gas Abstraction, the `paymasterData` parameter is not signed as well,
+so different Paymaster contracts can be used for subsequent authorized transactions using the same authorization.
 
 [//]: # (TODO: we need to provide `commitment` bytes to the invoker for validation, this function is one way to do it)
+We define the following Solidity structure to represent this transaction subtype on-chain:
+```solidity
+struct TransactionType4 {
+    address invokerAddress;
+    uint256 nonce;
+    uint256 commit;
+
+    uint256 paymasterGasLimit;
+    uint256 callGasLimit;
+    uint256 maxFeePerGas;
+    uint256 maxPriorityFeePerGas;
+    bytes paymasterData;
+    bytes callData;
+//    bytes signature; TODO rsv
+}
+```
 
 We then define the following Solidity method and the `invokerAddress` of the transaction is invoked with the
 corresponding data:
@@ -114,7 +235,6 @@ a randomized signature value, without ever knowing the ECDSA private key that wo
 Applying this approach to an `AUTHORIZED_EOA_SUBTYPE` transaction, a new account can be created,
 whose address is forever bound to `invokerAddress` and `commit`, without ever needing to deploy code for the contract.
 
-https://eips.ethereum.org/EIPS/eip-3074
 
 ### Gas-sponsored time-limited code injection EOA transaction subtype
 
@@ -125,7 +245,6 @@ INSERT_CODE_EOA_SUBTYPE
 This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to insert
 contract code in the context of the EOA sender.
 
-https://eips.ethereum.org/EIPS/eip-7377
 
 ## Rationale
 

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -42,7 +42,7 @@ Here is the list of EIPs that propose adding features to EOA accounts that are a
 Each one of these proposals introduces features that can benefit both existing users and potential future users of
 the Ethereum blockchain in multiple ways.
 
-However, together these proposals consist 3 different transaction types and 3 opcodes, which is probably unsustainable.
+However, together these proposals consist of 3 different transaction types and 3 opcodes, which is probably unsustainable.
 
 None of these proposals supports Gas Abstraction mechanism that would be conceptually similar to "Paymasters" - smart
 contracts capable of paying transaction gas, based on some on-chain validity function, but do not gain any

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -141,7 +141,7 @@ The field `atomicity` contains an RLP encoded array of `N` elements of `byte` "a
 Atomicity describes a behaviour in case of a top-level revert in one of the frames, and can take the following values:
 
 * `CONTINUE_ON_REVERT = 0` - ignores the reverted execution and continues executing the batch
-* `TERMINATE_ON_REVERT = 1` - stops the execution of the batch on the reverted execution, does not execute the remainder
+* `TERMINATE_ON_REVERT = 1` - stops the execution of the batch on the reverted execution without reverting previous calls in the batch. Does not execute the remainder 
 * `ROLLBACK_ON_REVERT = 2` - rolls back all state changes caused by all the execution frames in current transaction
 
 These parameters represent all the inputs necessary to perform `N` sub-transactions.

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -301,7 +301,7 @@ by any of these transaction subtypes. EOAs may be detected by performing an `ecr
 ## Security Considerations
 
 The `DELEGATED_EOA_SUBTYPE` and especially `AUTHORIZED_EOA_SUBTYPE` transactions add an ability for a contract to
-assume control over an EOA. This is a very powerful tool that has very serious security implications.
+assume control over an EOA. This is a very powerful tool that has serious security implications.
 
 Wallets must make sure the users know what they are signing and what the implications for the signing will be.
 Unlike other similar proposals that can rely on a fact that most wallet do not have an API to sign arbitrary data,

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -253,9 +253,6 @@ account should be set to.
 As the first step of processing the transaction, set the sender’s code to `state[tx.codeAddr].code`.
 Next, for each tuple in `storage` and the sender’s storage trie, set `storage[t.first] = t.second`.
 
-Now instantiate an EVM call into the sender's account using the same rules as EIP-1559 and set the
-transaction's origin to be `keccak256(sender)[0..20]`.
-
 ## Rationale
 
 ### Authorization as a transaction subtype instead of a family of opcodes

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -1,0 +1,138 @@
+---
+rip: 9999
+title: RIP-7560 Transaction Subtypes providing extended features for EOAs
+description: A set of RIP-7560 Transaction Subtypes that each extend the existing functionality of Externally Owned Accounts and improve overall experience for the users
+author: Yoav Weiss (@yoavw), Alex Forshtat (@forshtat), Dror Tirosh (@drortirosh), Shahaf Nacson (@shahafn)
+discussions-to:
+status: Draft
+type: Standards Track
+category: Core
+created:
+requires: 7560
+---
+
+## Abstract
+
+## Motivation
+
+## Specification
+
+### Gas-sponsored time-limited EOA transaction subtype
+
+```
+SPONSORED_EOA_SUBTYPE = x
+```
+
+This transaction subtype allows replacing a Smart Contract Account validation with a more familiar ECDSA validation
+pattern used in existing transaction types 0, 1 and 2.
+
+However, it retains the ability of an RIP-7560 transaction to include Paymaster data in order for the Paymaster
+contract to accept the gas charges. It also retains an ability to explicitly specify a time range where this
+transaction is valid, creating both "expiring" and "delayed" transactions.
+
+In case the `to` field is `nil`, `callData` is treated as `initCode` for the purpose of contract creation.
+
+https://eips.ethereum.org/EIPS/eip-2711
+
+### Gas-sponsored time-limited batched execution EOA transaction subtype
+
+```
+BATCHED_EOA_SUBTYPE = x
+```
+
+This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to initialize multiple
+EOA calls with a single signature and a single Paymaster validation.
+
+Fields `to` and `callData` are replaced with fields `targets` and `callDatas` containing RLP encoded arrays of values.
+
+The field `atomicity` contains an RLP encoded array of `byte` "atomicity" values.
+Atomicity describes a behaviour in case of a top-level revert in one of the frames, and can take the following values:
+
+* `CONTINUE_ON_REVERT = 0` - ignores the reverted execution and continues executing the batch
+* `TERMINATE_ON_REVERT = 1` - stops the execution of the batch on the reverted execution, does not execute the remainder
+* `ROLLBACK_ON_REVERT = 2` - rolls back all state changes caused by all the execution frames in current transaction
+
+https://eips.ethereum.org/EIPS/eip-2711
+
+### Gas-sponsored time-limited one-time delegated EOA transaction subtype
+
+```
+DELEGATED_EOA_SUBTYPE = x
+```
+
+This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to execute arbitrary
+contract code in the context of the EOA sender.
+
+Note that such transaction provides a one-time signature delegating execution to the `destination` contract,
+and this signature cannot be used repeatedly. The private key of the EOA will be needed to sign consequent delegations.
+
+TODO: Opcode restrictions (SSTORE, CREATE, CREATE2)
+See https://eips.ethereum.org/EIPS/eip-5806
+
+### Gas-sponsored time-limited reusable authorization EOA transaction subtype
+
+```
+AUTHORIZED_EOA_SUBTYPE = x
+```
+
+This transaction subtype extends the `DELEGATED_EOA_SUBTYPE` transactions with an ability to authorize arbitrary
+contract code to control the context of the EOA sender.
+
+The transaction signature (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the `secp256k1` curve over
+the message `keccak256(MAGIC || chainId || nonce || invokerAddress || commit)`.
+
+Note that account's `nonce` is not incremented when `AUTHORIZED_EOA_SUBTYPE` transaction is executed so the same
+authorization can be used unlimited number of times. In order to withdraw authorization, the account must perform
+any action that will increment its nonce.
+
+Transaction hash uniqueness is therefore not guaranteed by a nonce field, therefore must be explicitly be a requirement
+for a transaction validity:
+
+```
+AUTHORIZED_EOA_SUBTYPE is not valid if a transaction with identical hash has alredy been included in the current chain
+```
+
+Note that Paymaster Data is not signed, so different Paymaster contracts can be used for subsequent
+authorized transactions.
+
+[//]: # (TODO: we need to provide `commitment` bytes to the invoker for validation, this function is one way to do it)
+
+We then define the following Solidity method and the `invokerAddress` of the transaction is invoked with the
+corresponding data:
+
+```solidity
+
+    function executeAuthorizedTransaction(uint256 version, bytes32 txHash, bytes transaction) external;
+
+```
+
+#### Using permanent authorizations to create Smart Contract Accounts
+
+This approach relies on the so-called "Nick's method", which includes deriving an address from some data and
+a randomized signature value, without ever knowing the ECDSA private key that would be able to control this address.
+
+Applying this approach to an `AUTHORIZED_EOA_SUBTYPE` transaction, a new account can be created,
+whose address is forever bound to `invokerAddress` and `commit`, without ever needing to deploy code for the contract.
+
+https://eips.ethereum.org/EIPS/eip-3074
+
+### Gas-sponsored time-limited code injection EOA transaction subtype
+
+```
+INSERT_CODE_EOA_SUBTYPE
+```
+
+This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to insert
+contract code in the context of the EOA sender.
+
+https://eips.ethereum.org/EIPS/eip-7377
+
+## Rationale
+
+## Backwards Compatibility
+
+## Security Considerations
+
+## Copyright
+
+Copyright and related rights waived via [CC0](../LICENSE.md).

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -81,8 +81,7 @@ These are the shared parameters of any RIP-9999 transaction subtype payload:
   maxFeePerGas,
   validAfter,
   validUntil,
-  accessList,
-  yParity, r, s
+  accessList
 ```
 
 ### Gas-sponsored time-limited EOA transaction subtype
@@ -101,7 +100,8 @@ The transaction payload for this subtype is extended with the following fields:
 ```
  to
  value
- callGasLimit
+ callGasLimit,
+ yParity, r, s
 ```
 
 This change extends the ability of an RIP-7560 transaction to include Paymaster data in order for the Paymaster
@@ -130,7 +130,8 @@ The transaction payload for this subtype is extended with the following fields:
  targets
  values
  gasLimits
- atomicity
+ atomicity,
+ yParity, r, s
 ```
 The `targets` parameter is interpreted as an RPL encoding of `N` destination addressed.
 The `values` parameter is interpreted as an RPL encoding of `N` 256-bit amounts.
@@ -156,7 +157,8 @@ DELEGATED_EOA_SUBTYPE = x
 The transaction payload for this subtype is extended with the following fields:
 ```
  destination
- callGasLimit
+ callGasLimit,
+ yParity, r, s
 ```
 
 This transaction subtype extends the `SPONSORED_EOA_SUBTYPE` transactions with an ability to execute arbitrary
@@ -178,31 +180,49 @@ The transaction payload for this subtype is extended with the following fields:
  chainId,
  nonce,
  invokerAddress,
- commit,
  callData,
  callGasLimit
+ bigNonce, // TBD: in this transaction we would need both nonces - account state and 2D
+ validationGasLimit,
+ yParity, r, s
 ```
 
 This transaction subtype extends the `DELEGATED_EOA_SUBTYPE` transactions with an ability to authorize arbitrary
 contract code to control the context of the EOA sender.
 
 The transaction signature (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the `secp256k1` curve over
-the message `keccak256(MAGIC || chainId || nonce || invokerAddress || commit)`.
+the message `keccak256(MAGIC || chainId || nonce || implementationAddress || commit)`.
 
 Note that account's `nonce` is not incremented when `AUTHORIZED_EOA_SUBTYPE` transaction is executed so the same
 authorization can be used unlimited number of times. In order to withdraw authorization, the account must perform
 any action that will increment its nonce.
 
-Transaction hash uniqueness is therefore not guaranteed by a nonce field, therefore must be explicitly be a requirement
-for a transaction validity:
+Transaction hash uniqueness is therefore guaranteed by a `bigNonce` field for the `NonceManager` contract.
 
-```
-AUTHORIZED_EOA_SUBTYPE is not valid if a transaction with identical hash has alredy been included in the current chain
-```
+The main difference between `DELEGATED_EOA_SUBTYPE` and `AUTHORIZED_EOA_SUBTYPE` is that the transaction is handled
+as a full RIP-7560 Account Abstraction transaction.
 
-Note that most of the transaction fields are not signed by this transaction's signature. This means that the "invoker"
-contract is the entity responsible for implementing all kinds of protections, and the EOA account that signs an
-authorization fully cedes control to the "invoker" until the authorization is revoked.
+The `implementationAddress` will be invoked with the `validateTransaction` frame same as a regular
+Smart Contract Account would.
+This allows EOAs to temporarily transfer control of their assets to a Smart Contract Account but maintain an
+ability to revoke or override this authorisation.
+This also allows a cheap creation of AA accounts that do not require any code deployment, if the private key
+used to create the `yParity, r, s` signature does not exist.
+
+[//]: # (Transaction hash uniqueness is therefore not guaranteed by a nonce field, therefore must be explicitly be a requirement)
+
+[//]: # (for a transaction validity:)
+
+[//]: # ()
+[//]: # (```)
+
+[//]: # (AUTHORIZED_EOA_SUBTYPE is not valid if a transaction with identical hash has alredy been included in the current chain)
+
+[//]: # (```)
+
+Note that most of the transaction fields are not signed by this transaction's signature.
+This means that the "implementation" contract is the entity responsible for implementing all kinds of protections,
+and the EOA account that signs an authorization fully cedes control to the "invoker" until the authorization is revoked.
 
 For the purposes of Gas Abstraction, the `paymasterData` parameter is not signed as well,
 so different Paymaster contracts can be used for subsequent authorized transactions using the same authorization.

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -1,6 +1,6 @@
 ---
 rip: 9999
-title: RIP-7560 Transaction Subtypes providing extended features for EOAs
+title: A set of RIP-7560 Transaction Subtypes providing extended features for EOA improvement
 description: A set of RIP-7560 Transaction Subtypes that each extend the existing functionality of Externally Owned Accounts and improve overall experience for the users
 author: Yoav Weiss (@yoavw), Alex Forshtat (@forshtat), Dror Tirosh (@drortirosh), Shahaf Nacson (@shahafn)
 discussions-to:
@@ -15,7 +15,7 @@ requires: 7560
 
 Using the Gas Abstraction feature of [RIP-7560](./rip-7560.md) transactions with multiple execution frames,
 but applying the same approach to transactions authorized with a signature created by an Externally Owned Account,
-we define extensions to existing EOA behaviour that are consistent with the current state of Account Abstraction debate.
+we define extensions to existing EOA behaviour that are consistent with a vision for the future of Account Abstraction.
 
 ## Motivation
 
@@ -86,8 +86,6 @@ These are the shared parameters of any RIP-9999 transaction subtype payload:
 
 ### Gas-sponsored time-limited EOA transaction subtype
 
-[//]: # (TODO: remove this type, it is just a speacial case of batched tx with N=1)
-
 ```
 SPONSORED_EOA_SUBTYPE = x
 ```
@@ -104,8 +102,8 @@ The transaction payload for this subtype is extended with the following fields:
  yParity, r, s
 ```
 
-This change extends the ability of an RIP-7560 transaction to include Paymaster data in order for the Paymaster
-contract to accept the gas charges to all existing EOA accounts.
+This subtype extends the ability of an RIP-7560 transaction to specify a Paymaster contract, 
+which accepts the gas charges, to all EOA accounts.
 It also provided an EOA with an ability to explicitly specify a time range where this
 transaction is valid, creating both "expiring" and "delayed" transactions.
 
@@ -167,8 +165,6 @@ contract code in the context of the EOA sender.
 Note that such transaction provides a one-time signature delegating execution to the `destination` contract,
 and this signature cannot be used repeatedly. The private key of the EOA will be needed to sign consequent delegations.
 
-TODO: Opcode restrictions (SSTORE, CREATE, CREATE2)
-
 ### Gas-sponsored time-limited reusable authorization EOA transaction subtype
 
 ```
@@ -184,14 +180,18 @@ The transaction payload for this subtype is extended with the following fields:
  callGasLimit
  bigNonce, // TBD: in this transaction we would need both nonces - account state and 2D
  validationGasLimit,
+ commit, // 32 bytes hash
  yParity, r, s
 ```
 
-This transaction subtype extends the `DELEGATED_EOA_SUBTYPE` transactions with an ability to authorize arbitrary
-contract code to control the context of the EOA sender.
+This transaction subtype extends the `DELEGATED_EOA_SUBTYPE` transactions with an ability to authorize some
+contract code to act as a Smart Contract Account and control the context of the EOA sender.
 
 The transaction signature (`yParity`, `r`, `s`) are interpreted as an ECDSA signature on the `secp256k1` curve over
 the message `keccak256(MAGIC || chainId || nonce || implementationAddress || commit)`.
+
+The `commit` value is a hash values that the implementation will validate.
+It is passed to the validation frame as part of the encoded transaction structure. 
 
 Note that account's `nonce` is not incremented when `AUTHORIZED_EOA_SUBTYPE` transaction is executed so the same
 authorization can be used unlimited number of times. In order to withdraw authorization, the account must perform
@@ -209,50 +209,13 @@ ability to revoke or override this authorisation.
 This also allows a cheap creation of AA accounts that do not require any code deployment, if the private key
 used to create the `yParity, r, s` signature does not exist.
 
-[//]: # (Transaction hash uniqueness is therefore not guaranteed by a nonce field, therefore must be explicitly be a requirement)
-
-[//]: # (for a transaction validity:)
-
-[//]: # ()
-[//]: # (```)
-
-[//]: # (AUTHORIZED_EOA_SUBTYPE is not valid if a transaction with identical hash has alredy been included in the current chain)
-
-[//]: # (```)
-
 Note that most of the transaction fields are not signed by this transaction's signature.
 This means that the "implementation" contract is the entity responsible for implementing all kinds of protections,
-and the EOA account that signs an authorization fully cedes control to the "invoker" until the authorization is revoked.
+and the EOA account that signs an authorization fully cedes control to the "implementation" until
+the authorization is revoked.
 
 For the purposes of Gas Abstraction, the `paymasterData` parameter is not signed as well,
 so different Paymaster contracts can be used for subsequent authorized transactions using the same authorization.
-
-[//]: # (TODO: we need to provide `commitment` bytes to the invoker for validation, this function is one way to do it)
-We define the following Solidity structure to represent this transaction subtype on-chain:
-```solidity
-struct TransactionType4 {
-    address invokerAddress;
-    uint256 nonce;
-    uint256 commit;
-
-    uint256 paymasterGasLimit;
-    uint256 callGasLimit;
-    uint256 maxFeePerGas;
-    uint256 maxPriorityFeePerGas;
-    bytes paymasterData;
-    bytes callData;
-//    bytes signature; TODO rsv
-}
-```
-
-We then define the following Solidity method and the `invokerAddress` of the transaction is invoked with the
-corresponding data:
-
-```solidity
-
-    function executeAuthorizedTransaction(uint256 version, bytes32 txHash, bytes transaction) external;
-
-```
 
 #### Using permanent authorizations to create Smart Contract Accounts
 
@@ -260,10 +223,8 @@ This approach relies on the so-called "Nick's method", which includes deriving a
 a randomized signature value, without ever knowing the ECDSA private key that would be able to control this address.
 
 Applying this approach to an `AUTHORIZED_EOA_SUBTYPE` transaction, a new account can be created,
-whose address is forever bound to `invokerAddress` and `commit`, without ever needing to deploy code for the contract.
-
-[//]: # (TODO: 3074 allows a single transaction to carry multiple authorizations, and switch between them dynamically)
-[//]: # (TODO: should we try to do something similar with batched delegation/authorization?)
+whose address is forever bound to `implementationAddress` and `commit`,
+without ever needing to deploy code for the contract.
 
 ### Gas-sponsored time-limited code injection EOA transaction subtype
 
@@ -285,12 +246,23 @@ data,
 value
 ```
 
+[//]: # (TODO: TBD: this is copied directly from 7377 as it seems to apply well.)
+
+Unlike standard contract deployment, a migration transaction directly specifies what code value the sender's
+account should be set to.
+
+As the first step of processing the transaction, set the sender’s code to `state[tx.codeAddr].code`.
+Next, for each tuple in `storage` and the sender’s storage trie, set `storage[t.first] = t.second`.
+
+Now instantiate an EVM call into the sender's account using the same rules as EIP-1559 and set the
+transaction's origin to be `keccak256(sender)[0..20]`.
+
 ## Rationale
 
 ### Authorization as a transaction subtype instead of a family of opcodes
 
 Both approaches have their benefits and downsides.
-Here are ome of the benefits of a transaction subtype approach:
+Here are some of the benefits of a transaction subtype approach:
 
 * Use of `AUTH` and `AUTHCALL` opcodes only allow an unnecessarily dangerous way for EOAs to achieve Gas Abstraction.
 
@@ -304,9 +276,12 @@ A lot can go wrong with this approach.
 mechanism similar to [ERC-7562: Account Abstraction Validation Scope Rules](https://eips.ethereum.org/EIPS/eip-7562).
 
     It is impossible to retrofit such mechanism into legacy transaction types.
+    There is no way to check the `AUTH` signature other than by executing it, which probably means that
+    there will always be a risk of the wrapper transaction reverting, leaving the relay service with a loss.
 
 * Avoids exposing ECDSA signature and account nonces to the EVM opcodes.
     Using opcodes to verify authorization signature necessarily means that EVM becomes exposed to these details.
+    There are real issues with ECDSA signatures, so abstracting cryptography details from EVM opcodes is desired.
 
 * There is only a limited number of available opcodes across all L1 and L2 networks.
 
@@ -316,7 +291,20 @@ mechanism similar to [ERC-7562: Account Abstraction Validation Scope Rules](http
 
 ## Backwards Compatibility
 
+This RIP suggest creation of new RIP-7560 transaction subtypes, which by itself does not affect any existing contracts.
+
+However, any contract that assumes that an EOA may not have any code or storage, will have its expectations broken
+by any of these transaction subtypes. EOAs may be detected by performing an `ecrecover` or by accessing `tx.origin`. 
+
 ## Security Considerations
+
+The `DELEGATED_EOA_SUBTYPE` and especially `AUTHORIZED_EOA_SUBTYPE` transactions add an ability for a contract to
+assume control over an EOA. This is a very powerful tool that has very serious security implications.
+
+Wallets must make sure the users know what they are signing and what the implications for the signing will be.
+Unlike other similar proposals that can rely on a fact that most wallet do not have an API to sign arbitrary data,
+these transaction subtypes could potentially be signed with a regular `eth_signTransaction` API of a wallet
+with RIP-7560 support.
 
 ## Copyright
 

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -178,7 +178,6 @@ The transaction payload for this subtype is extended with the following fields:
  chainId,
  nonce,
  implementationAddress,
- callData,
  callGasLimit
  bigNonce, // TBD: in this transaction we would need both nonces - account state and 2D
  validationGasLimit,

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -175,8 +175,6 @@ AUTHORIZED_EOA_SUBTYPE = x
 
 The transaction payload for this subtype is extended with the following fields:
 ```
- chainId,
- nonce,
  implementationAddress,
  callGasLimit
  bigNonce, // TBD: in this transaction we would need both nonces - account state and 2D

--- a/RIPS/rip-9999.md
+++ b/RIPS/rip-9999.md
@@ -37,6 +37,7 @@ Here is the list of EIPs that propose adding features to EOA accounts that are a
 * [EIP-5081: Expirable Transaction](https://eips.ethereum.org/EIPS/eip-5081)
 * [EIP-5806: Delegate transaction](https://eips.ethereum.org/EIPS/eip-5806)
 * [EIP-7377: Migration Transaction](https://eips.ethereum.org/EIPS/eip-7377)
+* [EIP-7553: Separated Payer Transaction](https://eips.ethereum.org/EIPS/eip-7553)
 
 Each one of these proposals introduces features that can benefit both existing users and potential future users of
 the Ethereum blockchain in multiple ways.


### PR DESCRIPTION
Note that basic EOA tx is currently described in the RIP-7560 itself. It should be removed from there.