### PR TITLE
feat: add discount in `AA_BASE_GAS_COST` when using two-dimensional nonce

### DIFF
--- a/RIPS/rip-7712.md
+++ b/RIPS/rip-7712.md
@@ -39,6 +39,13 @@ with ERC-4337, as all ERC-4337 Smart Contract Accounts already use the solution 
 
 ## Specification
 
+### Constants
+
+| Name                     | Value |
+|--------------------------|-------|
+| AA_BASE_GAS_COST         | 15000 |
+| AA_BASE_GAS_COST_RIP7712 | 10000 |
+
 ### Non-sequential nonce support
 
 We propose an introduction of a `nonceKey` value used as a second dimension for the transaction `nonce` parameter.
@@ -62,6 +69,12 @@ Notice that this also prevents the previously signed `AA_TX_TYPE` transactions f
 The old `nonce` account parameter remains in use for transactions initiated by EOAs and for the `CREATE` opcode.
 
 It is not validated and not incremented when `sender` makes the `AA_TX_TYPE` transaction with `nonceKey != 0`.
+
+### Modification on `AA_BASE_GAS_COST`
+
+If an `AA_TX_TYPE` transaction is executed with nonceKey != 0, the NonceManager is called
+to validate and increment the nonce, bypassing the use of the legacy nonce parameter.
+In this scenario, the `AA_BASE_GAS_COST` is reduced to `AA_BASE_GAS_COST_RIP7712` to reflect the discounted gas cost.
 
 ### Deployment transaction
 
@@ -130,6 +143,16 @@ TODO.
 
 While there is no technical benefit to either option, allowing EVM code to control the nonce
 seems to be a smaller change to the Ethereum protocol and is more aligned with the vision of Account Abstraction.
+
+### Reducing the base gas cost for the `AA_TX_TYPE` transaction using two-dimensional nonce
+
+Using a two-dimensional nonce means that the legacy nonce is not being used. 
+However, since the `AA_BASE_GAS_COST` includes the cost for incrementing the legacy nonce, 
+this amount should be discounted from the gas calculation. As discussed in the [deployment section](#deployment-transaction), 
+the legacy nonce always starts from a non-zero value after account deployment. 
+
+Therefore, the cost that should be reduced can be considered equivalent to the cost of a non-zero to non-zero `SSTORE`, 
+which is defined as `5000` in [EIP-2200](https://eips.ethereum.org/EIPS/eip-2200).
 
 ## Backwards Compatibility
 


### PR DESCRIPTION
## Description

Added a sort of 'gas discount' when using two-dimensional nonce. The new `AA_BASE_GAS_COST_RIP7712` is set to be `10000`, which is 5000 gas lower than `AA_BASE_GAS_COST`, regarding the cost of nonzero to nonzero `SSTORE`.

Also updated the payload format for RIP-7712 transaction to include `nonceKey`.